### PR TITLE
Patched Fix Improper Handling of Exceptional Conditions in Newtonsoft…

### DIFF
--- a/Net/src/Net.csproj
+++ b/Net/src/Net.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>


### PR DESCRIPTION
….Json

Newtonsoft.Json vulnerable to Insecure Defaults due to improper handling of expressions with high nesting level that lead to StackOverFlow exception or high CPU and RAM usage. Exploiting this vulnerability results in Denial Of Service (DoS). The serialization and deserialization path have different properties regarding the issue.

Deserializing methods (like `JsonConvert.DeserializeObject`) will process the input that results in burning the CPU, allocating memory, and consuming a thread of execution. Quite high nesting level `(>10kk, or 9.5MB of {a:{a:{... input)` is needed to achieve the latency over 10 seconds, depending on the hardware.


To mitigate the issue one either need to update Newtonsoft.Json to 13.0.1 or set `MaxDepth` parameter in the `JsonSerializerSettings`. This can be done globally with the following statement. After that the parsing of the nested input will fail fast with `Newtonsoft.Json.JsonReaderException`:
```
JsonConvert.DefaultSettings = () => new JsonSerializerSettings { MaxDepth = 128 };
```
Repro code:
```
//Create a string representation of an highly nested object (JSON serialized)
int nRep = 25000;
string json = string.Concat(Enumerable.Repeat("{a:", nRep)) + "1" +
 string.Concat(Enumerable.Repeat("}", nRep));

//Parse this object (leads to high CPU/RAM consumption)
var parsedJson = JsonConvert.DeserializeObject(json);

// Methods below all throw stack overflow with nRep around 20k and higher
// string a = parsedJson.ToString();
// string b = JsonConvert.SerializeObject(parsedJson);
```
The original statement about the problem only affecting IIS applications is misleading. Any application is affected, however the IIS has a behavior that stops restarting the instance after some time resulting in a harder-to-fix DoS.**

## Impact
CWE-755
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`